### PR TITLE
Handle case where an instance has a PK but isn't saved yet.

### DIFF
--- a/linkcheck/listeners.py
+++ b/linkcheck/listeners.py
@@ -132,7 +132,7 @@ def delete_instance_links(sender, instance, **kwargs):
 
 
 def instance_pre_save(sender, instance, raw=False, **kwargs):
-    if not instance.pk or raw:
+    if instance._state.adding or not instance.pk or raw:
         # Ignore unsaved instances or raw imports
         return
     current_url = instance.get_absolute_url()


### PR DESCRIPTION
Added a check for `instance._state.adding` to `instance_pre_save` as checking `not instance.pk` is insufficient. In cases involving concrete model inheritance it can have a PK set but not be saved in the DB yet, which will call this to fail.