### PR TITLE
check_links: add concurrent version to speed up the `check_links` task

### DIFF
--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta
+from datetime import timedelta
 from http import HTTPStatus
 from io import StringIO
 from unittest.mock import Mock, patch
@@ -898,7 +898,7 @@ class ChecklinksTestCase(TestCase):
             "1 internal URLs and 0 external URLs have been checked.\n"
         )
 
-        yesterday = datetime.now() - timedelta(days=1)
+        yesterday = timezone.now() - timedelta(days=1)
         Url.objects.all().update(last_checked=yesterday)
         out = StringIO()
         call_command('checklinks', externalinterval=20, stdout=out)

--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime, timedelta
+from http import HTTPStatus
 from io import StringIO
 from unittest.mock import Mock, patch
 
@@ -13,6 +14,7 @@ from django.core.management.base import CommandError
 from django.test import LiveServerTestCase, TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
+from django.utils import timezone
 from requests.exceptions import ConnectionError
 
 from linkcheck.linkcheck_settings import MAX_URL_LENGTH
@@ -25,6 +27,7 @@ from linkcheck.listeners import (
     unregister_listeners,
 )
 from linkcheck.models import Link, Url
+from linkcheck.utils import check_links
 from linkcheck.views import get_jquery_min_js
 
 from .sampleapp.models import Author, Book, Journal, Page
@@ -1226,6 +1229,33 @@ class FilterCallableTestCase(TestCase):
             "Urls: 1 created, 0 deleted, 0 unchanged\n"
             "Links: 1 created, 0 deleted, 0 unchanged\n"
         )
+
+
+class TestCheckLinks(TestCase):
+
+    @requests_mock.Mocker()
+    def test_check_links(self, mocker):
+        good_url = 'https://example.com/good'
+        mocker.register_uri('HEAD', good_url, status_code=HTTPStatus.OK, reason='OK')
+        Url.objects.create(url=good_url)
+
+        bad_url = 'https://example.com/bad'
+        mocker.register_uri('HEAD', bad_url, status_code=HTTPStatus.NOT_FOUND, reason='NOT FOUND')
+        Url.objects.create(url=bad_url)
+
+        exception_url = 'https://example.com/exception'
+        mocker.register_uri('HEAD', exception_url, exc=ConnectionError("Something went wrong"))
+        Url.objects.create(url=exception_url)
+
+        recently_checked_url = 'https://example.com/recent'
+        # Shouldn't be requested
+        Url.objects.create(url=recently_checked_url, last_checked=timezone.now() - timedelta(days=1))
+
+        self.assertEqual(check_links(), 3)
+        self.assertEqual(Url.objects.get(url=good_url).status, True)
+        self.assertEqual(Url.objects.get(url=bad_url).status, False)
+        self.assertEqual(Url.objects.get(url=exception_url).status, False)
+        self.assertEqual(Url.objects.get(url=recently_checked_url).status, None)
 
 
 def get_command_output(command, *args, **kwargs):

--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -27,7 +27,7 @@ from linkcheck.listeners import (
     unregister_listeners,
 )
 from linkcheck.models import Link, Url
-from linkcheck.utils import check_links
+from linkcheck.utils import check_links, concurrent_check_links
 from linkcheck.views import get_jquery_min_js
 
 from .sampleapp.models import Author, Book, Journal, Page
@@ -1233,8 +1233,10 @@ class FilterCallableTestCase(TestCase):
 
 class TestCheckLinks(TestCase):
 
-    @requests_mock.Mocker()
-    def test_check_links(self, mocker):
+    def _setup_mock_urls(self, mocker):
+        """
+        Set up common mock URLs for link checking tests.
+        """
         good_url = 'https://example.com/good'
         mocker.register_uri('HEAD', good_url, status_code=HTTPStatus.OK, reason='OK')
         Url.objects.create(url=good_url)
@@ -1249,13 +1251,40 @@ class TestCheckLinks(TestCase):
 
         recently_checked_url = 'https://example.com/recent'
         # Shouldn't be requested
-        Url.objects.create(url=recently_checked_url, last_checked=timezone.now() - timedelta(days=1))
+        Url.objects.create(url=recently_checked_url, status=None, last_checked=timezone.now() - timedelta(days=1))
+
+        return (good_url, bad_url, exception_url, recently_checked_url)
+
+    @requests_mock.Mocker()
+    def test_check_links(self, mocker):
+        good_url, bad_url, exception_url, recently_checked_url = self._setup_mock_urls(mocker)
 
         self.assertEqual(check_links(), 3)
         self.assertEqual(Url.objects.get(url=good_url).status, True)
         self.assertEqual(Url.objects.get(url=bad_url).status, False)
         self.assertEqual(Url.objects.get(url=exception_url).status, False)
         self.assertEqual(Url.objects.get(url=recently_checked_url).status, None)
+
+    @requests_mock.Mocker()
+    def test_concurrent_check_links(self, mocker):
+        self._setup_mock_urls(mocker)
+
+        # Since the tests are running in sqlite, we can't insert data via our threaded code
+        # there's enough other test coverage that we can use `Url.save` as a proxy
+        with patch.object(Url, "save") as patched_save:
+            self.assertEqual(concurrent_check_links(), 3)
+            self.assertEqual(patched_save.call_count, 3)
+
+    def test_concurrent_check_links_error_handling(self):
+        Url.objects.create(url='https://example.com/good')
+        with (
+            patch("linkcheck.utils.logger.exception") as patched_logged_exception,
+            patch.object(Url, "check_external", side_effect=ValueError("oops")),
+        ):
+            self.assertEqual(concurrent_check_links(), 0)
+            self.assertEqual(patched_logged_exception.call_count, 1)
+            msg, *args = patched_logged_exception.call_args[0]
+            self.assertEqual(msg % tuple(args), "ValueError while checking https://example.com/good: oops")
 
 
 def get_command_output(command, *args, **kwargs):

--- a/linkcheck/utils.py
+++ b/linkcheck/utils.py
@@ -1,4 +1,6 @@
 import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import timedelta
 
 from django.apps import apps
@@ -116,6 +118,70 @@ def check_links(external_recheck_interval=10080, limit=-1, check_internal=True, 
         check_count += 1 if status is not None else 0
         if -1 < limit <= check_count:
             break
+
+    return check_count
+
+
+def concurrent_check_links(
+    external_recheck_interval=10080,
+    limit=-1,
+    check_internal=True,
+    check_external=True,
+    max_workers=20,
+):
+    """
+    Return the number of links effectively checked.
+    A concurrent version of `check_links`
+
+    Args:
+        external_recheck_interval: Minutes before rechecking external links
+        limit: Maximum number of URLs to check (-1 for unlimited)
+        check_internal: Whether to check internal links
+        check_external: Whether to check external links
+        max_workers: Maximum number of concurrent threads
+    """
+
+    urls = Url.objects.all()
+
+    # An optimization for when check_internal is False
+    if not check_internal:
+        recheck_datetime = timezone.now() - timedelta(minutes=external_recheck_interval)
+        urls = urls.exclude(last_checked__gt=recheck_datetime)
+
+    url_list = list(urls[:limit] if limit > 0 else urls)
+
+    if not url_list:
+        return 0
+
+    # Thread-safe counter
+    check_count = 0
+    count_lock = threading.Lock()
+
+    def check_single_url(url_obj):
+        """Check a single URL and return 1 if checked, 0 if not"""
+        try:
+            status = url_obj.check_url(check_internal=check_internal, check_external=check_external)
+            return 1 if status is not None else 0
+        except Exception as e:
+            logger.exception(
+                "%s while checking %s: %s",
+                type(e).__name__,
+                url_obj.url,
+                e
+            )
+            return 0
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        # Submit all tasks
+        future_to_url = {
+            executor.submit(check_single_url, url): url
+            for url in url_list
+        }
+        # Process completed futures
+        for future in as_completed(future_to_url):
+            result = future.result()
+            with count_lock:
+                check_count += result
 
     return check_count
 


### PR DESCRIPTION
When I tested this out on 1000 URLs in our `ukf` project, `check_links` took `1min 37s` and `concurrent_check_links` took `7.85 s` (with 20 workers) so a massive speed up is possible by utilizing `concurrent.futures` with the existing code.

There wasn't any code coverage of `check_links` so I added that, however it was a bit tricky to write good tests for the `concurrent_check_links` since this project is using sqlite as it's test db so concurrent writes aren't really possible.