### PR TITLE
Fix test failures for newer dependency versions and Python 3.14

### DIFF
--- a/linkcheck/models.py
+++ b/linkcheck/models.py
@@ -484,23 +484,30 @@ class Url(models.Model):
                 self.anchor_status = True
                 self.message += f", working {scope} hash anchor"
             else:
-                try:
-                    names = parse_anchors(html)
-                # Known possible errors include: AssertionError, NotImplementedError, UnicodeDecodeError
-                except Exception as e:
-                    logger.debug("%s while parsing anchors: %s", type(e).__name__, e)
+                # Check if content contains null bytes, indicating it's not valid HTML
+                # (e.g. binary content served with a text/html content type)
+                if isinstance(html, str) and '\x00' in html:
                     self.message += ", failed to parse HTML for anchor"
                     if not TOLERATE_BROKEN_ANCHOR:
                         self.status = False
                 else:
-                    if self.anchor in names:
-                        self.anchor_status = True
-                        self.message += f", working {scope} hash anchor"
-                    else:
-                        self.anchor_status = False
-                        self.message += f", broken {scope} hash anchor"
+                    try:
+                        names = parse_anchors(html)
+                    # Known possible errors include: AssertionError, NotImplementedError, UnicodeDecodeError
+                    except Exception as e:
+                        logger.debug("%s while parsing anchors: %s", type(e).__name__, e)
+                        self.message += ", failed to parse HTML for anchor"
                         if not TOLERATE_BROKEN_ANCHOR:
                             self.status = False
+                    else:
+                        if self.anchor in names:
+                            self.anchor_status = True
+                            self.message += f", working {scope} hash anchor"
+                        else:
+                            self.anchor_status = False
+                            self.message += f", broken {scope} hash anchor"
+                            if not TOLERATE_BROKEN_ANCHOR:
+                                self.status = False
         return self.anchor_status, self.anchor_message
 
 

--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -390,9 +390,11 @@ class ExternalCheckTestCase(LiveServerTestCase):
     def test_external_check_200_missing_cert(self):
         uv = Url(url=f"{self.live_server_url.replace('http://', 'https://')}/http/200/")
         uv.check_url()
-        self.assertEqual(uv.message, 'SSL Error: wrong version number')
-        self.assertEqual(uv.get_message, 'SSL Error: wrong version number')
-        self.assertEqual(uv.error_message, 'SSL Error: wrong version number')
+        # The specific SSL error message depends on the OpenSSL version:
+        # OpenSSL < 3.5: "wrong version number", OpenSSL >= 3.5: "record layer failure"
+        self.assertIn(uv.message, ['SSL Error: wrong version number', 'SSL Error: record layer failure'])
+        self.assertEqual(uv.get_message, uv.message)
+        self.assertEqual(uv.error_message, uv.message)
         self.assertEqual(uv.status, False)
         self.assertEqual(uv.anchor_message, '')
         self.assertEqual(uv.ssl_status, False)


### PR DESCRIPTION
While working on https://github.com/Beauhurst/django-linkcheck/pull/5 found some tests were failing on master. Gave this to GLM 5.1 to fix:

* Fixed `test_external_check_200_missing_cert` for OpenSSL >= 3.5, where the error message returned is different than before.
* Fixed `test_forged_video_with_time_anchor` by updating `Url.check_anchor`: Python 3.14's `HTMLParser` no longer raises exceptions on non-HTML content, so we now manually detect null bytes in HTML content string.
