### PR TITLE
Fix redirects from proxies

### DIFF
--- a/linkcheck/models.py
+++ b/linkcheck/models.py
@@ -266,6 +266,7 @@ class Url(models.Model):
         self.ssl_status = None
         self.error_message = ""
         self.message = ""
+        self.redirect_to = ""
 
     def check_url(self, check_internal=True, check_external=True, external_recheck_interval=EXTERNAL_RECHECK_INTERVAL):
         """
@@ -458,6 +459,23 @@ class Url(models.Model):
                 self.status_code = response.history[0].status_code
             else:
                 self.status_code = response.status_code
+                # Some proxies follow redirects upstream so response.history
+                # is empty; the final URL and the original status code are
+                # exposed via response headers.
+                resolved_url = response.headers.get("Resolved-Url")
+                if resolved_url and resolved_url != self.external_url:
+                    self.redirect_to = resolved_url
+                    initial_status = response.headers.get("Initial-Status-Code")
+                    if initial_status and initial_status.isdigit():
+                        initial_status_code = int(initial_status)
+                        self.redirect_status_code = response.status_code
+                        self.status_code = initial_status_code
+                        if response.ok:
+                            try:
+                                phrase = HTTPStatus(initial_status_code).phrase
+                            except ValueError:
+                                phrase = ""
+                            self.message = f"{initial_status_code} {phrase}".strip()
 
             # Check the anchor (if it exists)
             if fetch == requests.get:

--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -713,6 +713,109 @@ class ExternalCheckTestCase(LiveServerTestCase):
         self.assertEqual(last_request.scheme, 'http')
         self.assertEqual(last_request.proxies, {'http': 'http://proxy.example.com:8080'})
 
+    @patch(
+        'linkcheck.models.PROXIES',
+        {'http': 'http://proxy.example.com:8080'},
+    )
+    @patch('requests.head')
+    def test_external_proxy_redirect_with_resolved_url_and_status(self, mock_head):
+        """Proxy follows redirect upstream and exposes resolved URL and initial status via headers."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.reason = 'OK'
+        mock_response.history = []
+        mock_response.ok = True
+        mock_response.headers = {
+            'Resolved-Url': 'http://test.com/final/',
+            'Initial-Status-Code': '301',
+        }
+        mock_head.return_value = mock_response
+        uv = Url(url='http://test.com')
+        uv.check_url()
+        self.assertEqual(uv.status, True)
+        self.assertEqual(uv.message, '301 Moved Permanently')
+        self.assertEqual(uv.status_code, 301)
+        self.assertEqual(uv.redirect_status_code, 200)
+        self.assertEqual(uv.redirect_to, 'http://test.com/final/')
+        self.assertEqual(uv.type, 'external')
+
+    @patch(
+        'linkcheck.models.PROXIES',
+        {'http': 'http://proxy.example.com:8080'},
+    )
+    @patch('requests.head')
+    def test_external_proxy_redirect_with_resolved_url_no_initial_status(self, mock_head):
+        """Proxy exposes resolved URL but not initial status code."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.reason = 'OK'
+        mock_response.history = []
+        mock_response.ok = True
+        mock_response.headers = {
+            'Resolved-Url': 'http://test.com/final/',
+        }
+        mock_head.return_value = mock_response
+        uv = Url(url='http://test.com')
+        uv.check_url()
+        self.assertEqual(uv.status, True)
+        self.assertEqual(uv.message, '200 OK')
+        self.assertEqual(uv.status_code, 200)
+        self.assertEqual(uv.redirect_status_code, None)
+        self.assertEqual(uv.redirect_to, 'http://test.com/final/')
+        self.assertEqual(uv.type, 'external')
+
+    @patch(
+        'linkcheck.models.PROXIES',
+        {'http': 'http://proxy.example.com:8080'},
+    )
+    @patch('requests.head')
+    def test_external_proxy_redirect_same_url(self, mock_head):
+        """Resolved-Url matches the original URL, so no redirect is detected."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.reason = 'OK'
+        mock_response.history = []
+        mock_response.ok = True
+        mock_response.headers = {
+            'Resolved-Url': 'http://test.com',
+            'Initial-Status-Code': '301',
+        }
+        mock_head.return_value = mock_response
+        uv = Url(url='http://test.com')
+        uv.check_url()
+        self.assertEqual(uv.status, True)
+        self.assertEqual(uv.message, '200 OK')
+        self.assertEqual(uv.status_code, 200)
+        self.assertEqual(uv.redirect_status_code, None)
+        self.assertEqual(uv.redirect_to, '')
+        self.assertEqual(uv.type, 'external')
+
+    @patch(
+        'linkcheck.models.PROXIES',
+        {'http': 'http://proxy.example.com:8080'},
+    )
+    @patch('requests.head')
+    def test_external_proxy_redirect_not_ok(self, mock_head):
+        """Proxy redirect where final response is not OK (e.g. 404 after redirect)."""
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.reason = 'Not Found'
+        mock_response.history = []
+        mock_response.ok = False
+        mock_response.headers = {
+            'Resolved-Url': 'http://test.com/final/',
+            'Initial-Status-Code': '301',
+        }
+        mock_head.return_value = mock_response
+        uv = Url(url='http://test.com')
+        uv.check_url()
+        self.assertEqual(uv.status, False)
+        self.assertEqual(uv.message, '404 Not Found')
+        self.assertEqual(uv.status_code, 301)
+        self.assertEqual(uv.redirect_status_code, 404)
+        self.assertEqual(uv.redirect_to, 'http://test.com/final/')
+        self.assertEqual(uv.type, 'external')
+
     def test_external_check_timedout(self):
         uv = Url(url=f"{self.live_server_url}/timeout/")
         uv.check_url()


### PR DESCRIPTION
As @kristen-edwards  has noted, Linkcheck has not been recording redirects as expected. I examined responses from Scraping Bee (our proxy service) for known redirects, then gave the task to GLM 5.1. Tested this out manually on staging. Seems to work well, e.g. in 1000 requests:
```
Counter(Url.objects.filter(last_checked__date=dt.date(2026, 5, 5)).values_list("status_code", flat=True))
# Counter({200: 635, 301: 123, None: 68, 302: 17, 308: 10, 404: 8, 307: 7})
```

and

```
Url.objects.filter(last_checked__date=dt.date(2026, 5, 5)).exclude(redirect_to="").count()
# 157
```

Some of these are trivial http -> https changes, but some are more significant, e.g. `"https://ns1.com/" -> "https://www.ibm.com/products/ns1-connect"`

