### PR TITLE
Fixed `test_external_check_200_missing_cert` for OpenSSL versions where the error message returned is different.

### DIFF
--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -390,9 +390,11 @@ class ExternalCheckTestCase(LiveServerTestCase):
     def test_external_check_200_missing_cert(self):
         uv = Url(url=f"{self.live_server_url.replace('http://', 'https://')}/http/200/")
         uv.check_url()
-        self.assertEqual(uv.message, 'SSL Error: wrong version number')
-        self.assertEqual(uv.get_message, 'SSL Error: wrong version number')
-        self.assertEqual(uv.error_message, 'SSL Error: wrong version number')
+        # The specific SSL error message depends on the OpenSSL version:
+        # OpenSSL < 3.5: "wrong version number", OpenSSL >= 3.5: "record layer failure"
+        self.assertIn(uv.message, ['SSL Error: wrong version number', 'SSL Error: record layer failure'])
+        self.assertEqual(uv.get_message, uv.message)
+        self.assertEqual(uv.error_message, uv.message)
         self.assertEqual(uv.status, False)
         self.assertEqual(uv.anchor_message, '')
         self.assertEqual(uv.ssl_status, False)

--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -390,8 +390,7 @@ class ExternalCheckTestCase(LiveServerTestCase):
     def test_external_check_200_missing_cert(self):
         uv = Url(url=f"{self.live_server_url.replace('http://', 'https://')}/http/200/")
         uv.check_url()
-        # The specific SSL error message depends on the OpenSSL version:
-        # OpenSSL < 3.5: "wrong version number", OpenSSL >= 3.5: "record layer failure"
+        # The specific SSL error message depends on the OpenSSL version
         self.assertIn(uv.message, ['SSL Error: wrong version number', 'SSL Error: record layer failure'])
         self.assertEqual(uv.get_message, uv.message)
         self.assertEqual(uv.error_message, uv.message)


### PR DESCRIPTION
Fixed `test_external_check_200_missing_cert` for OpenSSL versions where the error message returned is different.

While working on https://github.com/Beauhurst/django-linkcheck/pull/5 found some tests were failing on master. Gave this to GLM 5.1 to fix.